### PR TITLE
Fix Windows glob path separators in node/supabase server.ts templates

### DIFF
--- a/eventmodelers-cli/stacks/node/templates/root/server.ts
+++ b/eventmodelers-cli/stacks/node/templates/root/server.ts
@@ -13,17 +13,18 @@ import {PostgresEventStore} from "@event-driven-io/emmett-postgresql";
 async function startServer() {
 
     const eventStore = await findEventstore()
-    const slicesBase = join(__dirname, 'dist/src/slices');
-    const routesPattern = join(slicesBase, '**/routes{,-*}.js');
+    const toGlobPath = (p: string) => p.split('\\').join('/');
+    const slicesBase = toGlobPath(join(__dirname, 'dist/src/slices'));
+    const routesPattern = `${slicesBase}/**/routes{,-*}.js`;
 
     const routeFiles = await glob(routesPattern, {nodir: true});
     console.log('Found route files:', routeFiles);
 
-    const processorPattern = join(slicesBase, '**/processor{,-*}.js');
+    const processorPattern = `${slicesBase}/**/processor{,-*}.js`;
     const processorFiles = await glob(processorPattern, {nodir: true});
     console.log('Found processor files:', processorFiles);
 
-    const commonPattern = join(__dirname, 'src/common/routes{,-*}.@(ts|js)');
+    const commonPattern = `${toGlobPath(join(__dirname, 'src/common'))}/routes{,-*}.@(ts|js)`;
     const commonRouteFiles = await glob(commonPattern, {nodir: true});
     console.log('Found common route files:', commonRouteFiles);
 

--- a/eventmodelers-cli/stacks/supabase/templates/root/server.ts
+++ b/eventmodelers-cli/stacks/supabase/templates/root/server.ts
@@ -14,20 +14,21 @@ import {PostgresEventStore} from "@event-driven-io/emmett-postgresql";
 async function startServer() {
 
     const eventStore = await findEventstore()
-    const slicesBase = join(__dirname, 'dist/src/slices');
-    const routesPattern = join(slicesBase, '**/routes{,-*}.js');
+    const toGlobPath = (p: string) => p.split('\\').join('/');
+    const slicesBase = toGlobPath(join(__dirname, 'dist/src/slices'));
+    const routesPattern = `${slicesBase}/**/routes{,-*}.js`;
 
     const routeFiles = await glob(routesPattern, {nodir: true});
     console.log('Found route files:', routeFiles);
 
-    const processorPattern = join(slicesBase, '**/processor{,-*}.js');
+    const processorPattern = `${slicesBase}/**/processor{,-*}.js`;
     const processorFiles = await glob(processorPattern, {nodir: true});
     console.log('Found processor files:', processorFiles);
 
     // Common routes (e.g. projection replay) are privileged/operational and are
     // only mounted when explicitly enabled via env.
     const commonRoutesEnabled = process.env.COMMON_ROUTES_ENABLED === 'true';
-    const commonPattern = join(__dirname, 'src/common/routes{,-*}.@(ts|js)');
+    const commonPattern = `${toGlobPath(join(__dirname, 'src/common'))}/routes{,-*}.@(ts|js)`;
     const commonRouteFiles = commonRoutesEnabled
         ? await glob(commonPattern, {nodir: true})
         : [];


### PR DESCRIPTION
## Summary

- `stacks/node/templates/root/server.ts` and `stacks/supabase/templates/root/server.ts` build their route/processor/common-route glob patterns with `path.join(__dirname, ...)`.
- On Windows, `path.join` produces backslash-separated paths (e.g. `D:\project\dist\src\slices\**\routes{,-*}.js`). The `glob` package treats `\` as an escape character in patterns, not a path separator, so every generated pattern silently matched zero files.
- Effect: `Found route files: []` / `Found processor files: []` / `Found common route files: []` on every Windows machine, regardless of what was actually compiled — a slice built by the build-kit agent never got wired up, with no error to point at the cause.

## Fix

Added a small `toGlobPath` helper (`p.split('\\').join('/')`) applied to the two `__dirname`-derived base paths before building the glob patterns, in both templates. Behavior on macOS/Linux is unchanged since `path.join` already uses `/` there.

## Test plan

- [x] Reproduced on Windows: `npm run dev` reported empty file lists for all three globs despite a compiled route existing under `dist/src/slices/.../routes.js`.
- [x] Applied the same fix locally in a project generated from the `node` stack, rebuilt, and confirmed `Found route files: [...routes.js]` is now reported and the route is mounted.
- [ ] Not independently verified against the `supabase` stack's server (same code path, not re-tested end-to-end since I don't have a supabase-stack project scaffolded).
